### PR TITLE
items_per_page to include a space

### DIFF
--- a/src/locale/en_US.js
+++ b/src/locale/en_US.js
@@ -1,6 +1,6 @@
 export default {
   // Options.jsx
-  items_per_page: '/page',
+  items_per_page: '/ page',
   jump_to: 'Goto',
   page: '',
 


### PR DESCRIPTION
For design consistency reasons, I would like to see the forward slash between spaces, not only in front of it.

Currently, this is the way it looks:
![image](https://cloud.githubusercontent.com/assets/14140226/17276041/24428e1a-5725-11e6-8f54-0de658863264.png)

And this would be the result of this small change:
![image](https://cloud.githubusercontent.com/assets/14140226/17276060/d46366ca-5725-11e6-81bc-ae5c5a85eed7.png)
