### PR TITLE
Replace <div> with <li> to follow HTML spec

### DIFF
--- a/src/Pagination.jsx
+++ b/src/Pagination.jsx
@@ -210,7 +210,7 @@ class Pagination extends React.Component {
           >
             <a />
           </li>
-          <div title={`${this.state.current}/${allPages}`} className={`${prefixCls}-simple-pager`}>
+          <li title={`${this.state.current}/${allPages}`} className={`${prefixCls}-simple-pager`}>
             <input
               type="text"
               value={this.state._current}
@@ -220,7 +220,7 @@ class Pagination extends React.Component {
             />
             <span className={`${prefixCls}-slash`}>／</span>
             {allPages}
-          </div>
+          </li>
           <li
             title={locale.next_page}
             onClick={this._next}


### PR DESCRIPTION
Hi,

Thank you for open sourcing this. It has helped me greatly.

The html specification states that only an `li` can be a direct child of `ul`.

This matters much more when server rendered and can potentially be causing the `Component's children should not be mutated` in #43.

Thank you

---

Edit: close: https://github.com/react-component/pagination/issues/43