### PR TITLE
Use "license" for string in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "bugs": {
     "url": "http://github.com/react-component/pagination/issues"
   },
-  "licenses": "MIT",
+  "license": "MIT",
   "files": [
     "lib",
     "assets/*.css"


### PR DESCRIPTION
`licenses` has been deprecated and should no longer be used

https://docs.npmjs.com/files/package.json#license