### PR TITLE
shouldnot always call setState in handleKeyUp func

### DIFF
--- a/src/Pagination.jsx
+++ b/src/Pagination.jsx
@@ -134,19 +134,22 @@ export default class Pagination extends React.Component {
 
   handleKeyUp = (e) => {
     const inputValue = e.target.value;
+    const currentInputValue = this.state.currentInputValue;
     let value;
 
     if (inputValue === '') {
       value = inputValue;
     } else if (isNaN(Number(inputValue))) {
-      value = this.state.currentInputValue;
+      value = currentInputValue;
     } else {
       value = Number(inputValue);
     }
 
-    this.setState({
-      currentInputValue: value,
-    });
+    if (value !== currentInputValue) {
+      this.setState({
+        currentInputValue: value,
+      });
+    }
 
     if (e.keyCode === KEYCODE.ENTER) {
       this.handleChange(value);


### PR DESCRIPTION
it will cause re-render with any keyboardEvent, isn't it ?
You could log in render func, and focus goto input, then press any key to reappear it.