### PR TITLE
fix(ru_RU.js): `/ странице` => `/ стр.`

### DIFF
--- a/src/locale/ru_RU.js
+++ b/src/locale/ru_RU.js
@@ -1,6 +1,6 @@
 export default {
   // Options.jsx
-  items_per_page: '/странице',
+  items_per_page: '/ стр.',
   jump_to: 'Перейти',
   jump_to_confirm: 'подтвердить',
   page: '',


### PR DESCRIPTION
Fixed this issue: https://github.com/ant-design/ant-design/issues/11079
`странице` - lexically incorrect for the Russian language in this context. A short form `стр.` is better suited though not ideal.