### PR TITLE
Adjust in pt_BR locale

### DIFF
--- a/src/locale/pt_BR.js
+++ b/src/locale/pt_BR.js
@@ -1,6 +1,6 @@
 export default {
   // Options.jsx
-  items_per_page: '/ páginas',
+  items_per_page: '/ página',
   jump_to: 'Vá até',
   jump_to_confirm: 'confirme',
   page: '',


### PR DESCRIPTION
items_per_page means that page is singular, so the translation must be 'página' (singular), not 'páginas' (plural)