### PR TITLE
Exposes buildOptionText property of Options component to Pagination c…

### DIFF
--- a/src/Pagination.jsx
+++ b/src/Pagination.jsx
@@ -48,6 +48,7 @@ class Pagination extends React.Component {
     showQuickJumper: PropTypes.oneOfType([PropTypes.bool, PropTypes.object]),
     showTitle: PropTypes.bool,
     pageSizeOptions: PropTypes.arrayOf(PropTypes.string),
+    pageSizeBuildOptionText: PropTypes.func,
     showTotal: PropTypes.func,
     locale: PropTypes.object,
     style: PropTypes.object,
@@ -661,6 +662,7 @@ class Pagination extends React.Component {
           current={this.state.current}
           pageSize={this.state.pageSize}
           pageSizeOptions={this.props.pageSizeOptions}
+          buildOptionText={this.props.pageSizeBuildOptionText}
           quickGo={this.shouldDisplayQuickJumper() ? this.handleChange : null}
           goButton={goButton}
         />


### PR DESCRIPTION
Exposes buildOptionText property of Options component to Pagination component.

pageSizeBuildOptionText allows the user to define a method to overwrite the default buildOptionText method inside the Option component, allowing for custom text. The motivation for this is to put the data length as the last option in pageSizeOptions and then use this custom method to covert the display text to say "All".
