### PR TITLE
fix: replace full-width character with half-width

### DIFF
--- a/src/Pagination.jsx
+++ b/src/Pagination.jsx
@@ -426,7 +426,7 @@ class Pagination extends React.Component {
               onChange={this.handleKeyUp}
               size="3"
             />
-            <span className={`${prefixCls}-slash`}>／</span>
+            <span className={`${prefixCls}-slash`}>/</span>
             {allPages}
           </li>
           <li


### PR DESCRIPTION
The character used in pagination is changed from '／' to '/'.
The full-width one is only used in some Chinese paragraph.

https://github.com/NG-ZORRO/ng-zorro-antd/pull/4371#discussion_r341892732