### PR TITLE
English typo correction

### DIFF
--- a/src/locale/en_GB.js
+++ b/src/locale/en_GB.js
@@ -1,7 +1,7 @@
 export default {
   // Options.jsx
   items_per_page: '/ page',
-  jump_to: 'Goto',
+  jump_to: 'Go to',
   jump_to_confirm: 'confirm',
   page: '',
 

--- a/src/locale/en_US.js
+++ b/src/locale/en_US.js
@@ -1,7 +1,7 @@
 export default {
   // Options.jsx
   items_per_page: '/ page',
-  jump_to: 'Goto',
+  jump_to: 'Go to',
   jump_to_confirm: 'confirm',
   page: '',
 


### PR DESCRIPTION
Replace 'Goto' with 'Go to'