### PR TITLE
added lithuanian language

### DIFF
--- a/src/locale/lt_LT.js
+++ b/src/locale/lt_LT.js
@@ -1,0 +1,15 @@
+export default {
+  // Options.jsx
+  items_per_page: '/ psl.',
+  jump_to: 'Pereiti',
+  jump_to_confirm: 'patvirtinti',
+  page: '',
+
+  // Pagination.jsx
+  prev_page: 'Atgal',
+  next_page: 'Pirmyn',
+  prev_5: 'Grįžti 5 pls.',
+  next_5: 'Peršokti 5 pls.',
+  prev_3: 'Grįžti 3 pls.',
+  next_3: 'Peršokti 3 pls.',
+};


### PR DESCRIPTION
Im using antdesign and they have dependencies to pagination version ~2.4.5 but there was no lithuanian language.