### PR TITLE
fix: pass label to `getItemIcon` to fix missing `aria-label`

### DIFF
--- a/src/Pagination.jsx
+++ b/src/Pagination.jsx
@@ -538,7 +538,7 @@ class Pagination extends React.Component {
             {itemRender(
               this.getJumpPrevPage(),
               'jump-prev',
-              this.getItemIcon(jumpPrevIcon),
+              this.getItemIcon(jumpPrevIcon, 'prev page'),
             )}
           </li>
         );
@@ -556,7 +556,7 @@ class Pagination extends React.Component {
             {itemRender(
               this.getJumpNextPage(),
               'jump-next',
-              this.getItemIcon(jumpNextIcon),
+              this.getItemIcon(jumpNextIcon, 'next page'),
             )}
           </li>
         );


### PR DESCRIPTION
Hello! Thanks for creating this library! This fixes an a11y warning I ran into in my application. 

Commit Summary
---- 
This fixes several accessibility warnings related to the jumper caused
by a missing `aria-label`. The fixes can be observed in the
`itemRender` and `jumper` stories in Storybook.

Screenshots
----

|Before | After|
|--|--|
| ![Screen Shot 2020-08-06 at 1 11 35 PM](https://user-images.githubusercontent.com/5473427/89578043-6d095700-d7e6-11ea-8fac-a4318ad9b76e.png) | ![Screen Shot 2020-08-06 at 1 09 44 PM](https://user-images.githubusercontent.com/5473427/89578088-7db9cd00-d7e6-11ea-83d6-5f32600786c1.png) |
| ![Screen Shot 2020-08-06 at 1 11 27 PM](https://user-images.githubusercontent.com/5473427/89578055-71357480-d7e6-11ea-9e87-b152d03322fa.png) | ![Screen Shot 2020-08-06 at 1 09 34 PM](https://user-images.githubusercontent.com/5473427/89578099-827e8100-d7e6-11ea-9597-8faa979d6cf7.png) |


And the missing `aria-label`: 

![Screen Shot 2020-08-06 at 1 10 04 PM](https://user-images.githubusercontent.com/5473427/89578188-a215a980-d7e6-11ea-8345-4a826af9b44a.png)





