### PR TITLE
SizeChanger is displayed automatically if the total is greater than 50 and the pageSize is not specified in the props

### DIFF
--- a/src/Pagination.jsx
+++ b/src/Pagination.jsx
@@ -293,7 +293,7 @@ class Pagination extends React.Component {
     if (typeof showSizeChanger !== 'undefined') {
       return showSizeChanger;
     }
-    return total > totalBoundaryShowSizeChanger;
+    return total > totalBoundaryShowSizeChanger && !('pageSize' in this.props);
   }
 
   runIfEnter = (event, callback, ...restParams) => {


### PR DESCRIPTION
SizeChanger will appear automatically when total is greater than 50, but if the size of pageszie is specified in props, clicking sizeChanger will not respond.Although this can be avoided in development by using defaultPagesize instead of pageszie or manually setting the showSizeChanger property to false, many older systems upgrade from antd 3.x or even antd 2.x to 4.x. Many older code specifies pagesize. It can be a lot of work to use defaultPagesize instead of pageszie or manually setting the showSizeChanger property to false.And unavoidably cause problems, so I think just simply by total more than 50 shows sizeChanger is not very reasonable, so it is easy to appear click sizeChanger without reaction, with the intention of improving the user experience, in conclusion, I think sizeChanger conditions should be changed to auto show, the total is not specified in more than 50 and props pageSzie would be better