### PR TITLE
fix: click some page & prev btn

### DIFF
--- a/src/Options.jsx
+++ b/src/Options.jsx
@@ -35,16 +35,16 @@ class Options extends React.Component {
     if (goButton || goInputText === '') {
       return;
     }
-    if (
-      e.relatedTarget &&
-      (e.relatedTarget.className.indexOf(`${rootPrefixCls}-prev`) >= 0 ||
-        e.relatedTarget.className.indexOf(`${rootPrefixCls}-next`) >= 0)
-    ) {
-      return;
-    }
     this.setState({
       goInputText: '',
     });
+    if (
+      e.relatedTarget &&
+      (e.relatedTarget.className.indexOf(`${rootPrefixCls}-item-link`) >= 0 ||
+        e.relatedTarget.className.indexOf(`${rootPrefixCls}-item`) >= 0)
+    ) {
+      return;
+    }
     quickGo(this.getValidValue());
   };
 
@@ -122,7 +122,7 @@ class Options extends React.Component {
           dropdownMatchSelectWidth={false}
           value={(pageSize || pageSizeOptions[0]).toString()}
           onChange={this.changeSize}
-          getPopupContainer={triggerNode => triggerNode.parentNode}
+          getPopupContainer={(triggerNode) => triggerNode.parentNode}
         >
           {options}
         </Select>

--- a/tests/jumper.test.js
+++ b/tests/jumper.test.js
@@ -38,6 +38,32 @@ describe('Pagination with jumper', () => {
     expect(wrapper.state().current).toBe(10);
     expect(onChange).not.toBeCalled();
   });
+
+  it('should not jumper when click pre/next button', () => {
+    const quickJumper = wrapper.find('.rc-pagination-options-quick-jumper');
+    const input = quickJumper.find('input');
+    input.simulate('change', { target: { value: '13' } });
+    const preBtn = wrapper.find('[aria-label="prev page"]').at(0);
+    preBtn.simulate('click');
+    expect(wrapper.state().current).toBe(9);
+    // expect(input.instance().value).toBe('');
+
+    input.simulate('change', { target: { value: '15' } });
+    const nextBtn = wrapper.find('[aria-label="next page"]').at(0);
+    nextBtn.simulate('click');
+    expect(wrapper.state().current).toBe(10);
+    // expect(input.instance().value).toBe('');
+  });
+
+  it('should not jumper when click page', () => {
+    const quickJumper = wrapper.find('.rc-pagination-options-quick-jumper');
+    const input = quickJumper.find('input');
+    input.simulate('change', { target: { value: '13' } });
+    const preBtn = wrapper.find('.rc-pagination-item-1').at(0);
+    preBtn.simulate('click');
+    expect(wrapper.state().current).toBe(1);
+    expect(input.instance().value).toBe('');
+  });
 });
 
 describe('simple quick jumper', () => {

--- a/tests/jumper.test.js
+++ b/tests/jumper.test.js
@@ -43,26 +43,28 @@ describe('Pagination with jumper', () => {
     const quickJumper = wrapper.find('.rc-pagination-options-quick-jumper');
     const input = quickJumper.find('input');
     input.simulate('change', { target: { value: '13' } });
-    const preBtn = wrapper.find('[aria-label="prev page"]').at(0);
-    preBtn.simulate('click');
-    expect(wrapper.state().current).toBe(9);
-    // expect(input.instance().value).toBe('');
-
-    input.simulate('change', { target: { value: '15' } });
-    const nextBtn = wrapper.find('[aria-label="next page"]').at(0);
-    nextBtn.simulate('click');
-    expect(wrapper.state().current).toBe(10);
-    // expect(input.instance().value).toBe('');
+    const mockEvent = {
+      relatedTarget: {
+        className: 'rc-pagination-item-link',
+      },
+    };
+    input.simulate('blur', mockEvent);
+    expect(input.instance().value).toBe('');
+    expect(onChange).not.toBeCalled();
   });
 
   it('should not jumper when click page', () => {
     const quickJumper = wrapper.find('.rc-pagination-options-quick-jumper');
     const input = quickJumper.find('input');
     input.simulate('change', { target: { value: '13' } });
-    const preBtn = wrapper.find('.rc-pagination-item-1').at(0);
-    preBtn.simulate('click');
-    expect(wrapper.state().current).toBe(1);
+    const mockEvent = {
+      relatedTarget: {
+        className: 'rc-pagination-item',
+      },
+    };
+    input.simulate('blur', mockEvent);
     expect(input.instance().value).toBe('');
+    expect(onChange).not.toBeCalled();
   });
 });
 


### PR DESCRIPTION
close https://github.com/ant-design/ant-design/issues/29512

---

之前有个判断 上一页下一页的按钮，但其实点击触发的不是相应的，而是里层的 -item-link。这里修复了下。

增加了 点击 分页的判断，同时这两种情况 都会清空 input 。
