### PR TITLE
fix: page focus when current not change

### DIFF
--- a/src/Pagination.jsx
+++ b/src/Pagination.jsx
@@ -90,6 +90,11 @@ class Pagination extends React.Component {
       if (lastCurrentNode && document.activeElement === lastCurrentNode) {
         lastCurrentNode.blur();
       }
+    } else if (this.paginationNode) {
+      const activeNode = this.paginationNode.querySelector(
+        `.${prefixCls}-item-active`,
+      );
+      activeNode?.focus();
     }
   }
 

--- a/src/Pagination.jsx
+++ b/src/Pagination.jsx
@@ -79,18 +79,19 @@ class Pagination extends React.Component {
     };
   }
 
-  componentDidUpdate(prevProps, prevState) {
+  componentDidUpdate() {
     // When current page change, fix focused style of prev item
     // A hacky solution of https://github.com/ant-design/ant-design/issues/8948
+    if (!this.paginationNode) {
+      return;
+    }
+
     const { prefixCls } = this.props;
-    if (prevState.current !== this.state.current && this.paginationNode) {
-      const lastCurrentNode = this.paginationNode.querySelector(
-        `.${prefixCls}-item-${prevState.current}`,
-      );
-      if (lastCurrentNode && document.activeElement === lastCurrentNode) {
-        lastCurrentNode.blur();
-      }
-    } else if (this.paginationNode) {
+    if (
+      document.activeElement.className !== 'rc-pagination-item-link' &&
+      document.activeElement.parentElement.className !==
+        'rc-pagination-options-quick-jumper'
+    ) {
       const activeNode = this.paginationNode.querySelector(
         `.${prefixCls}-item-active`,
       );
@@ -252,12 +253,10 @@ class Pagination extends React.Component {
         page = 1;
       }
 
-      if (!('current' in this.props)) {
-        this.setState({
-          current: page,
-          currentInputValue: page,
-        });
-      }
+      this.setState({
+        current: page,
+        currentInputValue: page,
+      });
 
       const { pageSize } = this.state;
       this.props.onChange(page, pageSize);


### PR DESCRIPTION
当 current 受控，传入固定值时，点击其他页数，会在页面上同时激活两个 active 样式

原页数为 active ，后面点击的 是 :focus 带出来的。

这里的解决方案是，当 state 更新时，判断如果 新旧一样，focus active node