### PR TITLE
fix(Pagination): onChange should be forbidden when total is zero

### DIFF
--- a/src/Pagination.jsx
+++ b/src/Pagination.jsx
@@ -170,7 +170,10 @@ class Pagination extends React.Component {
     this.paginationNode = node;
   };
 
-  isValid = (page) => isInteger(page) && page !== this.state.current;
+  isValid = (page) => {
+    const { total } = this.props;
+    return isInteger(page) && page !== this.state.current && isInteger(total) && total > 0;
+  };
 
   shouldDisplayQuickJumper = () => {
     const { showQuickJumper, pageSize, total } = this.props;

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -3,6 +3,27 @@ import { mount } from 'enzyme';
 import Select from 'rc-select';
 import Pagination from '../src';
 
+describe('Default Pagination', () => {
+  let wrapper;
+  const onChange = jest.fn();
+
+  beforeEach(() => {
+    wrapper = mount(<Pagination onChange={onChange} />);
+  });
+
+  afterEach(() => {
+    wrapper.unmount();
+    onChange.mockReset();
+  });
+
+  it('onChange should be forbidden when total is default', () => {
+    const pagers = wrapper.find('.rc-pagination-item');
+    const page1 = pagers.at(0);
+    page1.simulate('click');
+    expect(onChange).toBeCalledTimes(0);
+  });
+});
+
 describe('Uncontrolled Pagination', () => {
   let wrapper;
   const onChange = jest.fn();


### PR DESCRIPTION
#### 涉及组件
- Pagination
#### 问题描述
- 当 `total` =  0 时，不应该触发 `onChange` 事件。
#### 复现地址
- https://codesandbox.io/s/ji-ben-antd-4-17-0-alpha-0-forked-lo63f?file=/index.js