### PR TITLE
fix: support nullable pageSize

### DIFF
--- a/src/Pagination.jsx
+++ b/src/Pagination.jsx
@@ -65,7 +65,7 @@ class Pagination extends React.Component {
     }
 
     let pageSize = props.defaultPageSize;
-    if ('pageSize' in props) {
+    if (props.pageSize != null) {
       // eslint-disable-next-line prefer-destructuring
       pageSize = props.pageSize;
     }
@@ -104,7 +104,7 @@ class Pagination extends React.Component {
       }
     }
 
-    if ('pageSize' in props && props.pageSize !== prevState.pageSize) {
+    if (props.pageSize != null && props.pageSize !== prevState.pageSize) {
       let { current } = prevState;
       const newCurrent = calculatePage(props.pageSize, prevState, props);
       current = current > newCurrent ? newCurrent : current;
@@ -172,7 +172,12 @@ class Pagination extends React.Component {
 
   isValid = (page) => {
     const { total } = this.props;
-    return isInteger(page) && page !== this.state.current && isInteger(total) && total > 0;
+    return (
+      isInteger(page) &&
+      page !== this.state.current &&
+      isInteger(total) &&
+      total > 0
+    );
   };
 
   shouldDisplayQuickJumper = () => {

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -292,6 +292,11 @@ describe('Other props', () => {
         .getDOMNode().disabled,
     ).toBe(true);
   });
+
+  it('should not error on nullable pageSize', () => {
+    const wrapper = mount(<Pagination pageSize={null} />);
+    expect(wrapper.find('.rc-pagination').exists()).toBe(true);
+  });
 });
 
 // https://github.com/ant-design/ant-design/issues/10524


### PR DESCRIPTION
When `pageSize` is loaded via API, it could be `null/undefined` if API error, `calculatePage` will emit error before, this PR handles this case.

```tsx
<Pagination
  className="pagination text-right"
  pageSize={parsedPagination?.limit}
  current={parsedPagination?.page}
  total={parsedPagination?.total}
  selectComponentClass={PaginationSelect}
  showQuickJumper={true}
  showSizeChanger={true}
  showTotal={total => t('total_tiao', total)}
  onChange={onPaginationChange}
/>
```

---

cc @afc163 