### PR TITLE
නව භාෂාවක් එකතු කිරීම

### DIFF
--- a/src/locale/si_LK.ts
+++ b/src/locale/si_LK.ts
@@ -1,0 +1,16 @@
+export default {
+  // Options.jsx
+  items_per_page: '/ පිටුව',
+  jump_to: 'වෙත යන්න',
+  jump_to_confirm: 'තහවුරු',
+  page: 'පිටුව',
+
+  // Pagination.jsx
+  prev_page: 'කලින් පිටුව',
+  next_page: 'ඊළඟ පිටුව',
+  prev_5: 'කලින් පිටු 5',
+  next_5: 'ඊළඟ පිටු 5',
+  prev_3: 'කලින් පිටු 3',
+  next_3: 'ඊළඟ පිටු 3',
+  page_size: 'පිටුවේ ප්‍රමාණය',
+};


### PR DESCRIPTION
භාෂාවේ නම: Sinhalese / Sinhala
දේශීය නම: සිංහල
කේතය: සිං / si

`si_LK` is unnecessary but it seems we cannot use `si`