### PR TITLE
fix(): :bug: 每页数量下拉定位不准确

### DIFF
--- a/src/Options.jsx
+++ b/src/Options.jsx
@@ -122,7 +122,6 @@ class Options extends React.Component {
           dropdownMatchSelectWidth={false}
           value={(pageSize || pageSizeOptions[0]).toString()}
           onChange={this.changeSize}
-          getPopupContainer={(triggerNode) => triggerNode.parentNode}
           aria-label={locale.page_size}
           defaultOpen={false}
         >


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

[相关issue](https://github.com/react-component/pagination/issues/472)

### 💡 需求背景和解决方案

当pagination的祖先元素设置了transform的scale时，每页数量的下拉框的定位不准确。  

去除Select组件上的{ getPopupContainer: (triggerNode) => triggerNode.parentNode } props。  

### 📝 更新日志


| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |          |
| 🇨🇳 中文 |          |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供