### PR TITLE
fix(config): fix dynamic directory issue on windows

### DIFF
--- a/.dumirc.ts
+++ b/.dumirc.ts
@@ -6,4 +6,5 @@ export default defineConfig({
     name: 'Pagination',
     logo: 'https://avatars0.githubusercontent.com/u/9441414?s=200&v=4',
   },
+  exportStatic: false,
 });


### PR DESCRIPTION
What is the nature of this change?

* [ ] New feature submission
* [x] Routine bug fix
* [ ] Site/documentation improvement
* [ ] Demo code improvement
* [ ] Component style/interaction improvement
* [ ] TypeScript definition update
* [ ] Package size optimization
* [ ] Performance optimization
* [ ] Function enhancement
* [ ] Internationalization improvement
* [ ] Refactoring
* [ ] Code style optimization
* [ ] Test cases
* [ ] Branch merging
* [ ] Other changes (What are the changes about?)

🔗 Related Issue
[Related issue](https://github.com/react-component/pagination/issues/516)
fix #516

💡 Background and solution of the requirement
When doing `npm run now-build` a directory named like this is created: 
`C:\<project>\node_modules\rc-pagination\dist\~demos\:id`
This (`: in path`)  is not allowed on Windows, and fails. Same problem happens with [Bazel](https://www.bazel.build) - see [this issue](https://stackoverflow.com/questions/52429700/bazel-workaround-for-filenames-with-in-them) for example.
When explicitly setting `exportStatic` to `false` in the config file, this file is not produced, so that should take care of this issue.

Note, I can't read any kind of Chinese so I don't know for sure what the documentation says about this option:
https://v1.d.umijs.org/config#exportstatic

📝 Update log
Language Update Description
* [x] 🇺🇸 English
* [ ] 🇨🇳 Chinese

☑️ Self-checklist before requesting a merge
⚠️ Please self-check and tick all options. ⚠️

Documentation is supplemented or not required
* [x] Code demo is provided or not required
* [x] TypeScript definition is supplemented or not required
* [x] Changelog is provided or not required