### PR TITLE
fix: use popupMatchSelectWidth instead of dropdownMatchSelectWidth

### DIFF
--- a/src/Options.tsx
+++ b/src/Options.tsx
@@ -137,7 +137,7 @@ class Options extends React.Component<Props, State> {
           showSearch={false}
           className={`${prefixCls}-size-changer`}
           optionLabelProp="children"
-          dropdownMatchSelectWidth={false}
+          popupMatchSelectWidth={false}
           value={(pageSize || pageSizeOptions[0]).toString()}
           onChange={this.changeSize}
           getPopupContainer={(triggerNode) => triggerNode.parentNode}


### PR DESCRIPTION
close https://github.com/ant-design/ant-design/issues/42369