### PR TITLE
Update index.ts to fix typescript error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
 export { default } from './Pagination';
-export type * from './interface';
+export * from './interface';


### PR DESCRIPTION
Fixing https://github.com/react-component/pagination/issues/547 by changing the exporting of types to use a typescript safe notation