### PR TITLE
fix: block default events for the enter key

### DIFF
--- a/src/Pagination.tsx
+++ b/src/Pagination.tsx
@@ -248,6 +248,7 @@ const Pagination: React.FC<PaginationProps> = (props) => {
     callback,
     ...restParams
   ) {
+    event.preventDefault();
     if (
       event.key === 'Enter' ||
       event.charCode === KeyCode.ENTER ||


### PR DESCRIPTION
当点击下一页后按下enter键，预期是出现页数加一，但实际按下enter键除了会触发键盘事件还会默认触发元素的点击事件，所以会出现页数加二的情况，反之点击上一页然后按下enter键也是如此，页数会减二而不是预期的减一，最直接的解决办法是`event.preventDefault`阻止默认事件即可，但是也会想到即使不写键盘事件，点击下一页，此时元素已经获取到焦点，此时按下enter键也会默认触发元素的点击事件，达到页数加一的效果，那么写键盘事件是否是冗余代码？翻看了业内比较知名的mui与element-plus，似乎他们并没有专门关照enter键盘事件