### PR TITLE
fix: prevent double trigger on Enter key press

### DIFF
--- a/src/Pagination.tsx
+++ b/src/Pagination.tsx
@@ -254,6 +254,7 @@ const Pagination: React.FC<PaginationProps> = (props) => {
       event.charCode === KeyCode.ENTER ||
       event.keyCode === KeyCode.ENTER
     ) {
+      event.preventDefault();
       callback(...restParams);
     }
   }


### PR DESCRIPTION
This pull request fixes an issue where pressing the Enter key on a focused pagination button triggers the event handler twice. This happens because the button triggers a click event when Enter is pressed.

### Changes:

- Added event.preventDefault() in runIfEnter to prevent the default action.

### Linked Issue:

#600.