### PR TITLE
feat: add item for prev/next

### DIFF
--- a/src/Pagination.tsx
+++ b/src/Pagination.tsx
@@ -523,9 +523,10 @@ const Pagination: React.FC<PaginationProps> = (props) => {
         onClick={prevHandle}
         tabIndex={prevDisabled ? null : 0}
         onKeyDown={runIfEnterPrev}
-        className={classNames(`${prefixCls}-prev`, {
+        className={classNames(`${prefixCls}-prev`, paginationClassNames?.item, {
           [`${prefixCls}-disabled`]: prevDisabled,
         })}
+        style={styles?.item}
         aria-disabled={prevDisabled}
       >
         {prev}
@@ -551,9 +552,10 @@ const Pagination: React.FC<PaginationProps> = (props) => {
         onClick={nextHandle}
         tabIndex={nextTabIndex}
         onKeyDown={runIfEnterNext}
-        className={classNames(`${prefixCls}-next`, {
+        className={classNames(`${prefixCls}-next`, paginationClassNames?.item, {
           [`${prefixCls}-disabled`]: nextDisabled,
         })}
+        style={styles?.item}
         aria-disabled={nextDisabled}
       >
         {next}

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -260,6 +260,18 @@ describe('Other props', () => {
     expect(prev).toHaveStyle('color: red');
     expect(next).toHaveStyle('color: red');
   });
+  it('should have 5 items when there are 3 pages and current page is 2', () => {
+    const { container } = render(
+      <Pagination
+        total={15}
+        pageSize={5}
+        current={2}
+        classNames={{ item: 'custom-test' }}
+      />,
+    );
+    const items = container.querySelectorAll('.custom-test');
+    expect(items.length).toBe(5);
+  });
   it('should support custom default icon', () => {
     const nextIcon = () => <span>nextIcon</span>;
     const prevIcon = () => <span>prevIcon</span>;

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -251,8 +251,14 @@ describe('Other props', () => {
       />,
     );
     const item = container.querySelector('.rc-pagination-item');
+    const prev = container.querySelector('.rc-pagination-prev');
+    const next = container.querySelector('.rc-pagination-next');
     expect(item).toHaveClass('custom-test');
+    expect(prev).toHaveClass('custom-test');
+    expect(next).toHaveClass('custom-test');
     expect(item).toHaveStyle('color: red');
+    expect(prev).toHaveStyle('color: red');
+    expect(next).toHaveStyle('color: red');
   });
   it('should support custom default icon', () => {
     const nextIcon = () => <span>nextIcon</span>;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **样式**
  - 改进了分页控件中“上一页”和“下一页”按钮的视觉效果，新增灵活的样式定制支持，允许更精准地调整按钮外观，同时确保功能保持稳定不变。
- **测试**
  - 增加了对分页按钮样式和类名的测试，确保自定义样式正确应用于“上一页”和“下一页”按钮，并验证在特定条件下的渲染行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->