### PR TITLE
doc: download trend

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ React Pagination Component.
 [david-dev-url]: https://david-dm.org/react-component/pagination?type=dev
 [david-dev-image]: https://david-dm.org/react-component/pagination/dev-status.svg?style=flat-square
 [download-image]: https://img.shields.io/npm/dm/rc-pagination.svg?style=flat-square
-[download-url]: https://npmjs.org/package/rc-pagination
+[download-url]: https://npm-compare.com/rc-pagination/#timeRange=FIVE_YEARS
 [bundlephobia-url]: https://bundlephobia.com/result?p=rc-pagination
 [bundlephobia-image]: https://badgen.net/bundlephobia/minzip/rc-pagination
 [dumi-url]: https://github.com/umijs/dumi


### PR DESCRIPTION
Hi,
I've updated the download count badge that links to the npm download statistics on npm-compare.com, showing the download count over the past 5 years. This will help users quickly understand the [rc-pagination](https://npm-compare.com/rc-pagination/#timeRange=FIVE_YEARS)'s adoption and provide a more detailed download trend.

Let me know if there’s anything else I can do to improve this.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- 更新了README文档中的下载链接，现在提供关于软件包下载趋势的长时段（五年）对比信息。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->