### PR TITLE
fix: restrict Pagination QuickJumper to numeric input only

### DIFF
--- a/src/Options.tsx
+++ b/src/Options.tsx
@@ -60,7 +60,10 @@ const Options: React.FC<OptionsProps> = (props) => {
       : (value: string | number) => `${value} ${locale.items_per_page}`;
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setGoInputText(e.target.value);
+    const value = e.target.value;
+    if (/^\d*$/.test(value)) {
+      setGoInputText(value);
+    }
   };
 
   const handleBlur = (e: React.FocusEvent<HTMLInputElement, Element>) => {

--- a/tests/jumper.test.tsx
+++ b/tests/jumper.test.tsx
@@ -29,6 +29,8 @@ describe('Pagination with jumper', () => {
     expect(quickJumper).toBeTruthy();
     const input = quickJumper.querySelector('input');
     fireEvent.change(input, { target: { value: '-1' } });
+    expect(input.value).toBe('');
+    fireEvent.change(input, { target: { value: '1' } });
     fireEvent.keyUp(input, { key: 'Enter', keyCode: 13, which: 13 });
     expect($$('.rc-pagination-item-active')).toHaveTextContent('1');
     expect(onChange).toHaveBeenLastCalledWith(1, 10);


### PR DESCRIPTION
## 🐛 What problem does this PR solve?

Related to ant-design/ant-design#55637
close #664
close https://github.com/react-component/pagination/issues/663

Currently, the QuickJumper page input fields accept any characters (letters, symbols, etc.), which can cause confusion when users accidentally type non-numeric characters.

## ✨ What is changed and how it works?
**Changes:**
- Add input validation to QuickJumper to restrict input to numeric characters only
- Update test cases to verify non-numeric input is rejected
- Simple mode already handles validation through getValidValue function

**Behavior:**
- Users can only type digits (0-9) in QuickJumper input fields
- Non-numeric characters (e.g., '-', '&', letters) are blocked at input time
- Enter key navigation works correctly with validated input

### Before
```
User types: "abc123def"
Input shows: "abc123def" ❌
Page jumps to: unpredictable
```

### After
```
User types: "abc123def"
Input shows: "123" ✅
Page jumps to: 123 (or stays on current page if completely filtered)
```

## 🔗 Related Issues and PR

- ant-design/ant-design#55637
- ant-design/ant-design#55663


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 输入框验证改进：输入框现在仅接受数字字符，非数字输入会被忽略。
  * 快速跳转功能完善：输入无效值时会自动清空输入框。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->